### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -19,7 +19,7 @@ require_once(DOKU_PLUGIN.'action.php');
 class action_plugin_authorlist extends DokuWiki_Action_Plugin{
 
 	
-    function register(&$contr) {
+    function register(Doku_Event_Handler $contr) {
        // $contr->register_hook('TPL_ACT_RENDER','AFTER',$this,'renderAuthorlist');
        $contr->register_hook('PARSER_WIKITEXT_PREPROCESS','BEFORE',$this,'appendAuthors');
 

--- a/syntax.php
+++ b/syntax.php
@@ -72,7 +72,7 @@ class syntax_plugin_authorlist extends DokuWiki_Syntax_Plugin {
     * @param $handler Object reference to the Doku_Handler object.
     * @return Integer The current lexer state for the match.
     */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $match = strtolower(substr($match,10,-2)); //strip ~~AUTHORS: from start and ~~ from end
         $options = explode('&',$match);
         $data = array();
@@ -90,7 +90,7 @@ class syntax_plugin_authorlist extends DokuWiki_Syntax_Plugin {
    /**
     * Render the complete authorlist. 
     */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 		// Only if XHTML
         if($mode == 'xhtml' && !$data['off']){
 			global $INFO;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
